### PR TITLE
Provide the ability to define brackets colors in User Settings

### DIFF
--- a/.vsixmanifest
+++ b/.vsixmanifest
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Language="en-US" Id="rainbow-brackets" Version="0.0.6" Publisher="2gua"/>
+    <Identity Language="en-US" Id="rainbow-brackets" Version="0.0.7" Publisher="2gua"/>
     <DisplayName>Rainbow Brackets</DisplayName>
     <Description xml:space="preserve">A rainbow brackets extension for VS Code.</Description>
     <Tags>rainbow,bracket,brackets</Tags>
     <Categories>Other</Categories>
     <GalleryFlags>Public</GalleryFlags>
     <Properties>
-      
-      
+
+
       <Property Id="Microsoft.VisualStudio.Services.Links.Learn" Value="http://www.2gua.info/" />
       <Property Id="Microsoft.VisualStudio.Services.Branding.Color" Value="#5c2d91" />
       <Property Id="Microsoft.VisualStudio.Services.Branding.Theme" Value="dark" />
     </Properties>
-    
+
     <Icon>extension/images/rainbowBrackets.png</Icon>
   </Metadata>
   <Installation>

--- a/README.md
+++ b/README.md
@@ -8,9 +8,24 @@ The isolated right bracket will be highlighted in red.
 
 # Install
 
-Open up VS Code and hit `F1` and type `ext` select Install Extension and type `rainbow-brackets` hit enter and reload window to enable. 
+Open up VS Code and hit `F1` and type `ext` select Install Extension and type `rainbow-brackets` hit enter and reload window to enable.
+
+# Customize
+
+Open Settings (JSON) to customize the colors of the brackets if you don't like the default ones.
+
+```json
+    "rainbow_brackets.roundBracketsColor": [ "#e6b422", "#c70067", "#00a960", "#fc7482" ],
+    "rainbow_brackets.squareBracketsColor": [ "#33ccff", "#8080ff", "#0073a8" ],
+    "rainbow_brackets.squigglyBracketsColor": [ "#d4d4aa", "#d1a075", "#9c6628" ],
+    "rainbow_brackets.isolatedRightBracketsColor": "#e2041b",
+```
 
 # Updates
+
+##0.0.7
+
+- Provide the ability to define brackets colors in User Settings.
 
 ##0.0.6
 

--- a/out/src/extension.js
+++ b/out/src/extension.js
@@ -7,6 +7,22 @@ function activate(context) {
     var roundBracketsColor = ["#e6b422", "#c70067", "#00a960", "#fc7482"];
     var squareBracketsColor = ["#33ccff", "#8080ff", "#0073a8"];
     var squigglyBracketsColor = ["#d4d4aa", "#d1a075", "#9c6628"];
+    var isolatedRightBracketsColor = "#e2041b";
+    var config = vscode.workspace.getConfiguration("rainbow_brackets");
+    if (config) {
+        if (config.roundBracketsColor && config.roundBracketsColor instanceof Array) {
+            roundBracketsColor = config.roundBracketsColor;
+        }
+        if (config.squareBracketsColor && config.squareBracketsColor instanceof Array) {
+            squareBracketsColor = config.squareBracketsColor;
+        }
+        if (config.squigglyBracketsColor && config.squigglyBracketsColor instanceof Array) {
+            squigglyBracketsColor = config.squigglyBracketsColor;
+        }
+        if (config.isolatedRightBracketsColor && typeof config.isolatedRightBracketsColor === 'string') {
+            isolatedRightBracketsColor = config.isolatedRightBracketsColor;
+        }
+    }
     var roundBracketsDecorationTypes = [];
     var squareBracketsDecorationTypes = [];
     var squigglyBracketsDecorationTypes = [];
@@ -26,7 +42,7 @@ function activate(context) {
         }));
     }
     var isolatedRightBracketsDecorationTypes = vscode.window.createTextEditorDecorationType({
-        color: "#e2041b"
+        color: isolatedRightBracketsColor
     });
     var activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {


### PR DESCRIPTION
The default colors can now be overriden by the user settings json file by adding the following optional lines.

```json
    "rainbow_brackets.roundBracketsColor": [ "#e6b422", "#c70067", "#00a960", "#fc7482" ],
    "rainbow_brackets.squareBracketsColor": [ "#33ccff", "#8080ff", "#0073a8" ],
    "rainbow_brackets.squigglyBracketsColor": [ "#d4d4aa", "#d1a075", "#9c6628" ],
    "rainbow_brackets.isolatedRightBracketsColor": "#e2041b",
```
